### PR TITLE
Improve numerical robustness when extrapolating mie scattering

### DIFF
--- a/atmosphere/functions.glsl
+++ b/atmosphere/functions.glsl
@@ -1627,7 +1627,9 @@ function:
 #ifdef COMBINED_SCATTERING_TEXTURES
 vec3 GetExtrapolatedSingleMieScattering(
     IN(AtmosphereParameters) atmosphere, IN(vec4) scattering) {
-  if (scattering.r == 0.0) {
+  // Algebraically this can never be negative, but rounding errors can produce that effect for
+  // sufficiently short view rays.
+  if (scattering.r <= 0.0) {
     return vec3(0.0);
   }
   return scattering.rgb * scattering.a / scattering.r *


### PR DESCRIPTION
Resolves sparkling artifacts that can arise under certain configurations when the sun is at the horizon and occluded by geometry very close to the viewpoint.

Rounding errors can cause the `scattering` value passed in by the final call to `GetExtrapolatedSingleMieScattering` made by `GetSkyRadianceToPoint` to have a very small negative `r` channel, which resulted in dramatically amplifying the returned value rather than clamping it to zero. By being slightly more tolerant in the existing sanity-check on the function, we can prevent this for free.

Hooray for renderdoc's shiny new shader debugging tools!