### PR TITLE
Fix textures of different types use the same location

### DIFF
--- a/atmosphere/model.cc
+++ b/atmosphere/model.cc
@@ -1007,6 +1007,13 @@ void Model::SetProgramUniforms(
     glBindTexture(GL_TEXTURE_3D, optional_single_mie_scattering_texture_);
     glUniform1i(glGetUniformLocation(program, "single_mie_scattering_texture"),
         single_mie_scattering_texture_unit);
+  } else {
+    // Unused texture sampler, but bind a 3D texture to it anyway, just in case.
+    // Avoid GL_INVALID_OPERATION: Two textures of different types use the same sampler location.
+    GLint location = glGetUniformLocation(program, "single_mie_scattering_texture");
+    if (location != -1) {
+      glUniform1i(location, scattering_texture_unit);
+    }
   }
 }
 


### PR DESCRIPTION
Avoid use default location 0(already used for `sampler2D transmittance_texture`) for `sampler3D single_mie_scattering_texture`, otherwise calling [`glDrawArrays`](https://github.com/ebruneton/precomputed_atmospheric_scattering/blob/master/atmosphere/demo/demo.cc#L391) will cause a black window with error `GL_INVALID_OPERATION` on macOS M1.
