### PR TITLE
Removed double extrapolation of single mie scattering with COMBINED_SCATTERING_TEXTURES

### DIFF
--- a/atmosphere/functions.glsl
+++ b/atmosphere/functions.glsl
@@ -1849,10 +1849,6 @@ RadianceSpectrum GetSkyRadianceToPoint(
   scattering = scattering - shadow_transmittance * scattering_p;
   single_mie_scattering =
       single_mie_scattering - shadow_transmittance * single_mie_scattering_p;
-#ifdef COMBINED_SCATTERING_TEXTURES
-  single_mie_scattering = GetExtrapolatedSingleMieScattering(
-      atmosphere, vec4(scattering, single_mie_scattering.r));
-#endif
 
   // Hack to avoid rendering artifacts when the sun is below the horizon.
   single_mie_scattering = single_mie_scattering *


### PR DESCRIPTION
Hi! Looks like I found a bug with COMBINED_SCATTERING_TEXTURES. As you can see above, the `single_mie_scattering` is  already unpacked returned from the function `GetCombinedScattering`:

```glsl
IrradianceSpectrum GetCombinedScattering(
    IN(AtmosphereParameters) atmosphere,
    IN(ReducedScatteringTexture) scattering_texture,
    IN(ReducedScatteringTexture) single_mie_scattering_texture,
    Length r, Number mu, Number mu_s, Number nu,
    bool ray_r_mu_intersects_ground,
    OUT(IrradianceSpectrum) single_mie_scattering) {
...
#ifdef COMBINED_SCATTERING_TEXTURES
  vec4 combined_scattering =
      texture(scattering_texture, uvw0) * (1.0 - lerp) +
      texture(scattering_texture, uvw1) * lerp;
  IrradianceSpectrum scattering = IrradianceSpectrum(combined_scattering);
  single_mie_scattering =
      GetExtrapolatedSingleMieScattering(atmosphere, combined_scattering);
#else
...
  return scattering;
}
```

Therefore, re-unpacking to `single_mie_scattering` in a `GetSkyRadianceToPoint` looks incorrect.